### PR TITLE
Fix: Replace typing_extensions with stdlib typing and drop typer[all]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "gerrit-to-platform"
 dynamic = ["version"]
 description = "Gerrit to GitHub / GitLab"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE.txt"}
 
 authors = [
@@ -27,7 +27,7 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Build Tools",
@@ -38,7 +38,7 @@ classifiers = [
 
 dependencies = [
     "ghapi~=1.0.3",
-    "typer[all]>=0.15,<0.22",
+    "typer>=0.15",
     "xdg~=5.1.1"
 ]
 

--- a/src/gerrit_to_platform/change_merged.py
+++ b/src/gerrit_to_platform/change_merged.py
@@ -10,7 +10,7 @@
 """Handler for patchset-created events."""
 
 import typer
-from typing_extensions import Annotated
+from typing import Annotated
 
 from gerrit_to_platform.helpers import (
     find_and_dispatch,

--- a/src/gerrit_to_platform/comment_added.py
+++ b/src/gerrit_to_platform/comment_added.py
@@ -13,9 +13,9 @@ import os
 import re
 import time
 from pathlib import Path
+from typing import Annotated
 
 import typer
-from typing_extensions import Annotated
 
 from gerrit_to_platform.config import get_mapping
 from gerrit_to_platform.helpers import (

--- a/src/gerrit_to_platform/patchset_created.py
+++ b/src/gerrit_to_platform/patchset_created.py
@@ -9,8 +9,9 @@
 ##############################################################################
 """Handler for patchset-created events."""
 
+from typing import Annotated
+
 import typer
-from typing_extensions import Annotated
 
 from gerrit_to_platform.helpers import (
     find_and_dispatch,


### PR DESCRIPTION
## Summary

Fix CI test collection failures caused by missing `typing_extensions` module and deprecated `typer[all]` extra.

## Problem

All four test modules fail during collection with:
```
ModuleNotFoundError: No module named 'typing_extensions'
```

This stems from two interrelated issues:

1. **Source files import `from typing_extensions import Annotated`**, but `typing_extensions` is not a direct dependency. It arrived as a transitive dependency via older Typer versions, which is no longer reliable.

2. **The `typer[all]` extra no longer exists** as of Typer 0.22.0. Typer now bundles `rich` and `shellingham` directly. The previous constraint `typer[all]>=0.15,<0.22` also blocked adoption of newer Typer releases.

## Changes

### Source files (`change_merged.py`, `comment_added.py`, `patchset_created.py`)
- Replace `from typing_extensions import Annotated` with `from typing import Annotated`
- `Annotated` entered the standard library `typing` module in Python 3.9

### `pyproject.toml`
- Change `"typer[all]>=0.15,<0.22"` to `"typer>=0.15"` (drop removed `[all]` extra and version ceiling)
- Bump `requires-python` from `>=3.8` to `>=3.9` (Typer 0.21+ already requires Python >=3.9)
- Update classifiers: replace `Programming Language :: Python :: 3.8` with `3.9`

## Fixes
- Fixes #49
- Fixes #47